### PR TITLE
Make Sentry DSN configurable via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Before installing the GamerVII Launcher, ensure you have the following prerequis
    dotnet run --project path/to/your/project
    ```
 
+   The launcher uses Sentry for error reporting. Set the `SENTRY_DSN` environment
+   variable with your DSN before running if you want to enable reporting:
+   ```bash
+   export SENTRY_DSN="https://public@example.com/1"
+   ```
+
 ### Troubleshooting
 
 If you encounter any issues during the installation, ensure the following:

--- a/src/Gml.Launcher/Program.cs
+++ b/src/Gml.Launcher/Program.cs
@@ -82,7 +82,9 @@ internal class Program
     private static void InitializeSentry()
     {
         Debug.WriteLine($"[Gml][{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] Start sentry initialization");
-        var sentryUrl = GmlClientManager.GetSentryLink(ResourceKeysDictionary.Host).Result;
+        var sentryUrl = Environment.GetEnvironmentVariable("SENTRY_DSN");
+        if (string.IsNullOrWhiteSpace(sentryUrl))
+            sentryUrl = GmlClientManager.GetSentryLink(ResourceKeysDictionary.Host).Result;
 
         try
         {


### PR DESCRIPTION
## Summary
- read Sentry DSN from `SENTRY_DSN` environment variable
- document the environment variable in README

## Testing
- `dotnet build Gml.Launcher.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68854e294b908324880edb46b058fe04