### PR TITLE
Make host configurable via env var

### DIFF
--- a/src/Gml.Launcher/Assets/Resources/ResourceKeysDictionary.Template.cs
+++ b/src/Gml.Launcher/Assets/Resources/ResourceKeysDictionary.Template.cs
@@ -1,5 +1,7 @@
 ﻿namespace Gml.Launcher.Assets;
 
+using System;
+
 public static class ResourceKeysDictionary
 {
     public const string MainPageTitle = "DefaultPageTitle";
@@ -30,6 +32,12 @@ public static class ResourceKeysDictionary
     public const string FailedOs = "FailedOs";
     public const string JavaNotFound = "JavaNotFound";
     public const string IsDiskFull = "IsDiskFull";
-    public const string Host = "{{HOST}}";
+    public static string Host
+    {
+        get
+        {
+            return Environment.GetEnvironmentVariable("GML_HOST") ?? "{{HOST}}";
+        }
+    }
     public const string FolderName = "{{FOLDER_NAME}}";
 }

--- a/src/Gml.Launcher/Assets/Resources/ResourceKeysDictionary.cs
+++ b/src/Gml.Launcher/Assets/Resources/ResourceKeysDictionary.cs
@@ -1,5 +1,7 @@
 ﻿namespace Gml.Launcher.Assets;
 
+using System;
+
 public static class ResourceKeysDictionary
 {
     public const string MainPageTitle = "DefaultPageTitle";
@@ -31,6 +33,20 @@ public static class ResourceKeysDictionary
     public const string JavaNotFound = "JavaNotFound";
     public const string IsDiskFull = "IsDiskFull";
     // public const string Host = "https://gmlb.recloud.tech";
-    public const string Host = "http://10.0.10.74:5000";
+#if DEBUG
+    private const string DevelopmentHost = "http://10.0.10.74:5000";
+#endif
+    public static string Host
+    {
+        get
+        {
+            var host = Environment.GetEnvironmentVariable("GML_HOST");
+#if DEBUG
+            if (string.IsNullOrWhiteSpace(host))
+                host = DevelopmentHost;
+#endif
+            return host ?? string.Empty;
+        }
+    }
     public const string FolderName = "GamerVIILacunerhV2";
 }

--- a/src/Gml.Launcher/Core/Extensions/ServiceLocator.cs
+++ b/src/Gml.Launcher/Core/Extensions/ServiceLocator.cs
@@ -77,7 +77,8 @@ public static class ServiceLocator
     private static GmlClientManager RegisterGmlManager(SystemService systemService, string installationDirectory,
         string[] arguments)
     {
-        var manager = new GmlClientManager(installationDirectory, ResourceKeysDictionary.Host,
+        var host = ResourceKeysDictionary.Host;
+        var manager = new GmlClientManager(installationDirectory, host,
             ResourceKeysDictionary.FolderName,
             systemService.GetOsType());
 #if DEBUG

--- a/src/Gml.Launcher/Program.cs
+++ b/src/Gml.Launcher/Program.cs
@@ -83,8 +83,9 @@ internal class Program
     {
         Debug.WriteLine($"[Gml][{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] Start sentry initialization");
         var sentryUrl = Environment.GetEnvironmentVariable("SENTRY_DSN");
+        var host = ResourceKeysDictionary.Host;
         if (string.IsNullOrWhiteSpace(sentryUrl))
-            sentryUrl = GmlClientManager.GetSentryLink(ResourceKeysDictionary.Host).Result;
+            sentryUrl = GmlClientManager.GetSentryLink(host).Result;
 
         try
         {


### PR DESCRIPTION
## Summary
- use env var `GML_HOST` for the API host with a debug fallback
- pass configured host to `GmlClientManager`
- update Sentry initialization to use configurable host

## Testing
- `dotnet test --no-build` *(fails: project files not found)*

------
https://chatgpt.com/codex/tasks/task_e_68855407a5148324add5a58950d6aa7e