### PR TITLE
Add RemoveAsync for clearing user storage

### DIFF
--- a/src/Gml.Launcher/Core/Services/IStorageService.cs
+++ b/src/Gml.Launcher/Core/Services/IStorageService.cs
@@ -30,6 +30,13 @@ public interface IStorageService
     Task<T?> GetAsync<T>(string key);
 
     /// <summary>
+    ///     Removes a value associated with the specified key.
+    /// </summary>
+    /// <param name="key">Key of value to remove.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task RemoveAsync(string key);
+
+    /// <summary>
     ///     Saves a record of type T to the storage service.
     /// </summary>
     /// <typeparam name="T">The type of the record to save.</typeparam>

--- a/src/Gml.Launcher/Core/Services/LocalStorageService.cs
+++ b/src/Gml.Launcher/Core/Services/LocalStorageService.cs
@@ -57,6 +57,11 @@ public class LocalStorageService : IStorageService
         return default;
     }
 
+    public Task RemoveAsync(string key)
+    {
+        return _database.DeleteAsync<StorageItem>(key);
+    }
+
     public Task<int> SaveRecord<T>(T record)
     {
         return _database.InsertOrReplaceAsync(record);

--- a/src/Gml.Launcher/ViewModels/Pages/OverviewPageViewModel.cs
+++ b/src/Gml.Launcher/ViewModels/Pages/OverviewPageViewModel.cs
@@ -169,7 +169,7 @@ public class OverviewPageViewModel : PageViewModelBase
     {
         return Dispatcher.UIThread.InvokeAsync(async () =>
         {
-            await _storageService.SetAsync<IUser?>(StorageConstants.User, null);
+            await _storageService.RemoveAsync(StorageConstants.User);
             _mainViewModel.Router.Navigate.Execute(new LoginPageViewModel(_mainViewModel, _onClosed));
         });
     }

--- a/src/Gml.Launcher/ViewModels/SplashScreenViewModel.cs
+++ b/src/Gml.Launcher/ViewModels/SplashScreenViewModel.cs
@@ -113,7 +113,7 @@ public class SplashScreenViewModel : WindowViewModelBase
         if (claims?.Value == user.Name)
             return true;
 
-        await _storageService.SetAsync<IUser?>(StorageConstants.User, null).ConfigureAwait(false);
+        await _storageService.RemoveAsync(StorageConstants.User).ConfigureAwait(false);
 
         return false;
     }
@@ -126,7 +126,7 @@ public class SplashScreenViewModel : WindowViewModelBase
         if (userData.User.IsAuth)
             return userData.User.IsAuth;
 
-        await _storageService.SetAsync<IUser?>(StorageConstants.User, null).ConfigureAwait(false);
+        await _storageService.RemoveAsync(StorageConstants.User).ConfigureAwait(false);
 
         return userData.User.IsAuth;
     }


### PR DESCRIPTION
## Summary
- extend `IStorageService` with `RemoveAsync`
- implement `RemoveAsync` in `LocalStorageService`
- clear stored user info with `RemoveAsync` when logging out or token is invalid

## Testing
- `dotnet restore src/Gml.Launcher/Gml.Launcher.csproj`
- `dotnet build src/Gml.Launcher/Gml.Launcher.csproj --no-restore` *(fails: missing submodules)*

------
https://chatgpt.com/codex/tasks/task_e_688554138a948324bae5b11815f0894c