### PR TITLE
Use JWT validation with server key

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Before installing the GamerVII Launcher, ensure you have the following prerequis
    export SENTRY_DSN="https://public@example.com/1"
    ```
 
+   To validate authentication tokens, set the `GML_JWT_KEY` environment variable
+   with the server's public key or HMAC secret:
+   ```bash
+   export GML_JWT_KEY="<server-key>"
+   ```
+
 ### Troubleshooting
 
 If you encounter any issues during the installation, ensure the following:


### PR DESCRIPTION
## Summary
- validate stored JWT token using server key
- document GML_JWT_KEY environment variable for configuring the key

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_6885f9fab3508324ac22bb85017d502e